### PR TITLE
Fix memory values to be compatible with fargate

### DIFF
--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -34,12 +34,12 @@ variable "desired_task_count" {
 variable "required_cpus" {
   type        = number
   description = "The required cpu resource for this service. 1024 here is 1 vCPU"
-  default     = 128 # defaulted low for dev environments, override for production
+  default     = 256
 }
 variable "required_memory" {
   type        = number
   description = "The required memory for this service"
-  default     = 256 # defaulted low for node service in dev environments, override for production
+  default     = 512
 }
 variable "use_fargate" {
   type        = bool


### PR DESCRIPTION
This pr fixes the default cpu and memory values so that when added to the eric values the total is fargate compatible. The fargate compatible values can be seen here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html#fargate-tasks-size