### PR TITLE
Integrated changes from SDK renaming field 'county' to 'townOrCity'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<structured-logging.version>3.0.1</structured-logging.version>
 		<api-security-java-version>2.0.3</api-security-java-version>
 		<api-sdk-manager-java-library.version>3.0.4</api-sdk-manager-java-library.version>
-		<private-api-sdk-java.version>4.0.28</private-api-sdk-java.version>
+		<private-api-sdk-java.version>4.0.36</private-api-sdk-java.version>
 
 	</properties>
 	<dependencyManagement>

--- a/src/main/java/uk/gov/companieshouse/presenter/account/mapper/api/AddressApiMapper.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/mapper/api/AddressApiMapper.java
@@ -13,7 +13,7 @@ public class AddressApiMapper implements Mapper<PresenterAccountAddressApi, Pres
         return PresenterAccountAddressApiBuilder.createPresenterAccountAddressApi()
                 .withAddressLine1(value.addressLine1())
                 .withAddressLine2(value.addressLine2())
-                .withCounty(value.county())
+                .withTownOrCity(value.townOrCity())
                 .withCountry(value.country())
                 .withPostcode(value.postcode())
                 .withPremises(value.premises())

--- a/src/main/java/uk/gov/companieshouse/presenter/account/mapper/request/PresenterAccountAddressMapper.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/mapper/request/PresenterAccountAddressMapper.java
@@ -1,10 +1,9 @@
 package uk.gov.companieshouse.presenter.account.mapper.request;
 
 import org.springframework.stereotype.Component;
-
 import uk.gov.companieshouse.presenter.account.exceptionhandler.ValidationException;
-import uk.gov.companieshouse.presenter.account.model.PresenterAccountAddress;
 import uk.gov.companieshouse.presenter.account.mapper.Mapper;
+import uk.gov.companieshouse.presenter.account.model.PresenterAccountAddress;
 import uk.gov.companieshouse.presenter.account.model.request.PresenterAddressRequest;
 
 @Component
@@ -16,7 +15,7 @@ public class PresenterAccountAddressMapper implements Mapper<PresenterAccountAdd
             return new PresenterAccountAddress(value.premises(),
                     value.addressLine1(),
                     value.addressLine2(),
-                    value.county(),
+                    value.townOrCity(),
                     value.country(),
                     value.postcode());
         } else {

--- a/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddress.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddress.java
@@ -8,7 +8,7 @@ public record PresenterAccountAddress(
         @Field("premises") String premises,
         @Field("addressLine1") String addressLine1,
         @Field("addressLine2") String addressLine2,
-        @Field("county") String county,
+        @Field("townOrCity") String townOrCity,
         @Field("country") String country,
         @Field("postCode") String postcode) {
 
@@ -23,13 +23,13 @@ public record PresenterAccountAddress(
             final String premises,
             final String addressLine1,
             final String addressLine2,
-            final String county,
+            final String townOrCity,
             final String country,
             final String postcode) {
         this.premises = validatePremises(premises);
         this.addressLine1 = validateAddressLine1(addressLine1);
         this.addressLine2 = validateAddressLine2(addressLine2);
-        this.county = validatedCounty(county);
+        this.townOrCity = validatedTownOrCity(townOrCity);
         this.country = validateCountry(country);
         this.postcode = validatePostcode(postcode);
     }
@@ -50,11 +50,11 @@ public record PresenterAccountAddress(
         }
     }
 
-    private String validatedCounty(final String line) {
+    private String validatedTownOrCity(final String line) {
         if (line == null || line.isBlank()) {
             return "";
         } else {
-            return getValidatedLine(line, COUNTY_MAX_LENGTH, "county failed validation");
+            return getValidatedLine(line, COUNTY_MAX_LENGTH, "townOrCity failed validation");
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/presenter/account/model/request/PresenterAccountDetailsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/model/request/PresenterAccountDetailsRequest.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.presenter.account.model.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record PresenterAccountDetailsRequest(
-        @JsonProperty("chsUserId") String userId,
+        @JsonProperty("userId") String userId,
         String email,
         PresenterNameRequest name,
         PresenterAddressRequest address) {

--- a/src/main/java/uk/gov/companieshouse/presenter/account/model/request/PresenterAddressRequest.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/model/request/PresenterAddressRequest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record PresenterAddressRequest(String premises,
                                       String addressLine1,
                                       String addressLine2,
-                                      String county,
+                                      String townOrCity,
                                       String country,
                                       @JsonProperty("postCode") String postcode) {
     @Override

--- a/src/test/java/uk/gov/companieshouse/presenter/account/controller/PresenterAccountControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/controller/PresenterAccountControllerTest.java
@@ -110,7 +110,7 @@ class PresenterAccountControllerTest {
                 new PresenterAccountAddress("premises",
                         "addressLine1",
                         "addressLine2",
-                        "county",
+                        "townOrCity",
                         "country",
                         "postcode"));
         Optional<PresenterAccountDetails> optionalPresenterAccountDetails = Optional.of(presenterAccountDetails);

--- a/src/test/java/uk/gov/companieshouse/presenter/account/mapper/PresenterAccountAddressMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/mapper/PresenterAccountAddressMapperTest.java
@@ -34,7 +34,7 @@ class PresenterAccountAddressMapperTest {
         assertEquals(premises, accountAddress.premises());
         assertEquals(line1, accountAddress.addressLine1());
         assertEquals("", accountAddress.addressLine2());
-        assertEquals("", accountAddress.county());
+        assertEquals("", accountAddress.townOrCity());
         assertEquals(country, accountAddress.country());
         assertEquals(postcode, accountAddress.postcode());
     }

--- a/src/test/java/uk/gov/companieshouse/presenter/account/mapper/api/AddressApiMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/mapper/api/AddressApiMapperTest.java
@@ -16,7 +16,7 @@ class AddressApiMapperTest {
         PresenterAccountAddress address = new PresenterAccountAddress("premises",
                 "addressLine1",
                 "addressLine2",
-                "County",
+                "townOrCity",
                 "Country",
                 "Postcode");
 
@@ -26,7 +26,7 @@ class AddressApiMapperTest {
         // then
         assertEquals(address.addressLine1(), addressApi.getAddressLine1());
         assertEquals(address.addressLine2(), addressApi.getAddressLine2());
-        assertEquals(address.county(), addressApi.getCounty());
+        assertEquals(address.townOrCity(), addressApi.getTownOrCity());
         assertEquals(address.country(), addressApi.getCountry());
         assertEquals(address.postcode(), addressApi.getPostcode());
         assertEquals(address.premises(), addressApi.getPremises());

--- a/src/test/java/uk/gov/companieshouse/presenter/account/mapper/api/DetailsApiMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/mapper/api/DetailsApiMapperTest.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.presenter.account.mapper.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +54,7 @@ class DetailsApiMapperTest {
                 .withPremises("Premises")
                 .withAddressLine1("addressLine1")
                 .withAddressLine2("addressLine2")
-                .withCounty("County")
+                .withTownOrCity("Town Or City")
                 .withCountry("Country")
                 .withPostcode("Postcode")
                 .build());

--- a/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddressTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddressTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
 import uk.gov.companieshouse.presenter.account.exceptionhandler.ValidationException;
 
 class PresenterAccountAddressTest {
@@ -15,7 +14,7 @@ class PresenterAccountAddressTest {
     private final static String PREMISES = "premise";
     private final static String FIRST_LINE = "first line";
     private final static String SECOND_LINE = "second line";
-    private final static String COUNTY = "county";
+    private final static String COUNTY = "townOrCity";
     private final static String COUNTRY = "country";
     private final static String POSTCODE = "postcode";
     private final static String STRING_TOO_LONG = "a".repeat(41);
@@ -35,13 +34,13 @@ class PresenterAccountAddressTest {
     }
 
     @Test
-    @DisplayName("Create a valid presenter address with both second line and county empty")
+    @DisplayName("Create a valid presenter address with both second line and townOrCity empty")
     void testValidPresenterAddressWithoutSecondLineAndCounty() {
         address = new PresenterAccountAddress(PREMISES, FIRST_LINE, "", "", COUNTRY, POSTCODE);
     }
 
     @Test
-    @DisplayName("Create a valid presenter address with both second line and county null")
+    @DisplayName("Create a valid presenter address with both second line and townOrCity null")
     void testValidPresenterAddressWithSecondLineAndCountyAsNull() {
         address = new PresenterAccountAddress(PREMISES, FIRST_LINE, null, null, COUNTRY, POSTCODE);
     }

--- a/src/test/java/uk/gov/companieshouse/presenter/account/service/PresenterAccountServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/service/PresenterAccountServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import java.util.regex.Pattern;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -94,7 +93,7 @@ class PresenterAccountServiceTest {
                 new PresenterAccountAddress("premises",
                         "addressLine1",
                         "addressLine2",
-                        "county",
+                        "townOrCity",
                         "country",
                         "postcode"));
 


### PR DESCRIPTION
Integrated changes from [this pull request](https://github.com/companieshouse/private-api-sdk-java/pull/465) which chnages the field `county` to `townOrCity` in the PresenterAccoutnAddress model.