### PR TITLE
Allow name fields to be null

### DIFF
--- a/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountName.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountName.java
@@ -2,12 +2,13 @@ package uk.gov.companieshouse.presenter.account.model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import org.springframework.lang.Nullable;
 import uk.gov.companieshouse.presenter.account.exceptionhandler.ValidationException;
 import uk.gov.companieshouse.presenter.account.validation.utils.StringValidator;
 
 public record PresenterAccountName(
-        @Field("forename") String forename,
-        @Field("surname") String surname) {
+        @Field("forename") @Nullable String forename,
+        @Field("surname") @Nullable String surname) {
 
     private static final int MAX_FORENAME_LENGTH = 32;
     private static final int MAX_SURNAME_LENGTH = 40;
@@ -18,11 +19,17 @@ public record PresenterAccountName(
     }
 
     private String validateName(final String name, final int maxLength) {
+        // CHS user profiles often don't have associated forename and surnames
+        // Therefore null is a valid value for the name field.
+        if (name == null) {
+            return null;
+        }
+
         if (StringValidator.validateString(name, maxLength)) {
             return name;
-        } else {
-            throw new ValidationException("Invalid Name");
         }
+
+        throw new ValidationException("Invalid Name");
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountName.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountName.java
@@ -21,11 +21,7 @@ public record PresenterAccountName(
     private String validateName(final String name, final int maxLength) {
         // CHS user profiles often don't have associated forename and surnames
         // Therefore null is a valid value for the name field.
-        if (name == null) {
-            return null;
-        }
-
-        if (StringValidator.validateString(name, maxLength)) {
+        if (name == null || StringValidator.validateString(name, maxLength)) {
             return name;
         }
 

--- a/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountNameTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountNameTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.presenter.account.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,5 +64,15 @@ class PresenterAccountNameTest {
         });
         assertTrue(firstNameException.getMessage().contains("Name"));
         assertTrue(surnameException.getMessage().contains("Name"));
+    }
+
+    @Test
+    @DisplayName("Allows for null forename and surname in PresenterAccountName")
+    void testAllowsForNullForenameAndSurname() {
+        try {
+            new PresenterAccountName(null, null);
+        } catch (Exception e) {
+            fail("Creation of PresenterAccountName should not fail with null forename and surname");
+        }
     }
 }


### PR DESCRIPTION
Changed the Name model file validations to allow fields to be null to match the changes made to the [`presenter-account-web`](https://github.com/companieshouse/presenter-account-web/pull/35) and [`private-api-sdk-node`](https://github.com/companieshouse/private-api-sdk-node/pull/117).
This is needed as CHS users often do not have an associated forename and surename leading to those values being null.