### PR TITLE
Make the town or city field mandatory

### DIFF
--- a/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddress.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddress.java
@@ -51,11 +51,7 @@ public record PresenterAccountAddress(
     }
 
     private String validatedTownOrCity(final String line) {
-        if (line == null || line.isBlank()) {
-            return "";
-        } else {
-            return getValidatedLine(line, COUNTY_MAX_LENGTH, "townOrCity failed validation");
-        }
+        return getValidatedLine(line, COUNTY_MAX_LENGTH, "townOrCity failed validation");
     }
 
     private String validateCountry(final String line) {

--- a/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddress.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddress.java
@@ -15,7 +15,7 @@ public record PresenterAccountAddress(
     private static final int PREMISES_MAX_LENGTH = 40;
     private static final int LINE_1_MAX_LENGTH = 40;
     private static final int LINE_2_MAX_LENGTH = 40;
-    private static final int COUNTY_MAX_LENGTH = 40;
+    private static final int TOWN_OR_CITY_MAX_LENGTH = 40;
     private static final int COUNTRY_MAX_LENGTH = 40;
     private static final int POSTCODE_MAX_LENGTH = 10;
 
@@ -51,7 +51,7 @@ public record PresenterAccountAddress(
     }
 
     private String validatedTownOrCity(final String line) {
-        return getValidatedLine(line, COUNTY_MAX_LENGTH, "townOrCity failed validation");
+        return getValidatedLine(line, TOWN_OR_CITY_MAX_LENGTH, "townOrCity failed validation");
     }
 
     private String validateCountry(final String line) {

--- a/src/test/java/uk/gov/companieshouse/presenter/account/mapper/PresenterAccountAddressMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/mapper/PresenterAccountAddressMapperTest.java
@@ -18,6 +18,7 @@ class PresenterAccountAddressMapperTest {
 
     private final static String premises = "a";
     private final static String line1 = "b";
+    private final static String townOrCity = "t";
     private final static String country = "e";
     private final static String postcode = "f";
 
@@ -29,12 +30,12 @@ class PresenterAccountAddressMapperTest {
     @Test
     @DisplayName("Mapping from presenter address to presenter account address")
     void mapperTest() {
-        PresenterAddressRequest address = new PresenterAddressRequest(premises, line1, null, null, country, postcode);
+        PresenterAddressRequest address = new PresenterAddressRequest(premises, line1, null, townOrCity, country, postcode);
         PresenterAccountAddress accountAddress = mapper.map(address);
         assertEquals(premises, accountAddress.premises());
         assertEquals(line1, accountAddress.addressLine1());
         assertEquals("", accountAddress.addressLine2());
-        assertEquals("", accountAddress.townOrCity());
+        assertEquals(townOrCity, accountAddress.townOrCity());
         assertEquals(country, accountAddress.country());
         assertEquals(postcode, accountAddress.postcode());
     }

--- a/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddressTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddressTest.java
@@ -14,7 +14,7 @@ class PresenterAccountAddressTest {
     private final static String PREMISES = "premise";
     private final static String FIRST_LINE = "first line";
     private final static String SECOND_LINE = "second line";
-    private final static String COUNTY = "townOrCity";
+    private final static String TOWN_OR_CITY = "townOrCity";
     private final static String COUNTRY = "country";
     private final static String POSTCODE = "postcode";
     private final static String STRING_TOO_LONG = "a".repeat(41);
@@ -30,26 +30,26 @@ class PresenterAccountAddressTest {
     @Test
     @DisplayName("Create a valid presenter address")
     void testValidPresenterAddress() {
-        address = new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, COUNTY, COUNTRY, POSTCODE);
+        address = new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, TOWN_OR_CITY, COUNTRY, POSTCODE);
     }
 
     @Test
-    @DisplayName("Create a valid presenter address with both second line and townOrCity empty")
-    void testValidPresenterAddressWithoutSecondLineAndCounty() {
-        address = new PresenterAccountAddress(PREMISES, FIRST_LINE, "", "", COUNTRY, POSTCODE);
+    @DisplayName("Create a valid presenter address with both second line empty null")
+    void testValidPresenterAddressWithoutSecondLine() {
+        address = new PresenterAccountAddress(PREMISES, FIRST_LINE, "", TOWN_OR_CITY, COUNTRY, POSTCODE);
     }
 
     @Test
-    @DisplayName("Create a valid presenter address with both second line and townOrCity null")
-    void testValidPresenterAddressWithSecondLineAndCountyAsNull() {
-        address = new PresenterAccountAddress(PREMISES, FIRST_LINE, null, null, COUNTRY, POSTCODE);
+    @DisplayName("Create a valid presenter address with second line null")
+    void testValidPresenterAddressWithSecondLineAsNull() {
+        address = new PresenterAccountAddress(PREMISES, FIRST_LINE, null, TOWN_OR_CITY, COUNTRY, POSTCODE);
     }
 
     @Test
     @DisplayName("Throw ValidationException by creating an invalid presenter address with empty premises")
     void testInvalidPresenterAddressWithoutPremises() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress("", FIRST_LINE, SECOND_LINE, COUNTY, COUNTRY, POSTCODE);
+            new PresenterAccountAddress("", FIRST_LINE, SECOND_LINE, TOWN_OR_CITY, COUNTRY, POSTCODE);
         });
         assertTrue(e.getMessage().contains("premises"));
     }
@@ -58,16 +58,25 @@ class PresenterAccountAddressTest {
     @DisplayName("Throw ValidationException by creating an invalid presenter address with empty first line")
     void testInvalidPresenterAddressWithoutFirstLine() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(PREMISES, "", SECOND_LINE, COUNTY, COUNTRY, POSTCODE);
+            new PresenterAccountAddress(PREMISES, "", SECOND_LINE, TOWN_OR_CITY, COUNTRY, POSTCODE);
         });
         assertTrue(e.getMessage().contains("address line 1"));
+    }
+
+    @Test
+    @DisplayName("Throw ValidationException by creating an invalid presenter address with empty town or city")
+    void testInvalidPresenterAddressWithoutTownOrCity() {
+        Exception e = assertThrows(ValidationException.class, () -> {
+            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, "", COUNTRY, POSTCODE);
+        });
+        assertTrue(e.getMessage().contains("town or city"));
     }
 
     @Test
     @DisplayName("Throw ValidationException by creating an invalid presenter address with empty country")
     void testInvalidPresenterAddressWithoutCountry() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, COUNTY, "", POSTCODE);
+            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, TOWN_OR_CITY, "", POSTCODE);
         });
         assertTrue(e.getMessage().contains("country"));
     }
@@ -76,7 +85,7 @@ class PresenterAccountAddressTest {
     @DisplayName("Throw ValidationException by creating an invalid presenter address with empty postcode")
     void testInvalidPresenterAddressWithoutPostcode() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, COUNTY, COUNTRY, "");
+            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, TOWN_OR_CITY, COUNTRY, "");
         });
         assertTrue(e.getMessage().contains("postcode"));
     }
@@ -85,7 +94,7 @@ class PresenterAccountAddressTest {
     @DisplayName("Throw ValidationException by creating an invalid presenter address with too long premises")
     void testInvalidPresenterAddressWithTooLongPremises() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(STRING_TOO_LONG, FIRST_LINE, SECOND_LINE, COUNTY, COUNTRY, POSTCODE);
+            new PresenterAccountAddress(STRING_TOO_LONG, FIRST_LINE, SECOND_LINE, TOWN_OR_CITY, COUNTRY, POSTCODE);
         });
         assertTrue(e.getMessage().contains("premises"));
     }
@@ -94,7 +103,7 @@ class PresenterAccountAddressTest {
     @DisplayName("Throw ValidationException by creating an invalid presenter address with too long first line")
     void testInvalidPresenterAddressWithTooLongFirstLine() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(PREMISES, STRING_TOO_LONG, SECOND_LINE, COUNTY, COUNTRY, POSTCODE);
+            new PresenterAccountAddress(PREMISES, STRING_TOO_LONG, SECOND_LINE, TOWN_OR_CITY, COUNTRY, POSTCODE);
         });
         assertTrue(e.getMessage().contains("address line 1"));
     }
@@ -103,7 +112,7 @@ class PresenterAccountAddressTest {
     @DisplayName("Throw ValidationException by creating an invalid presenter address with too long second line")
     void testInvalidPresenterAddressWithTooLongSecondLine() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(PREMISES, FIRST_LINE, STRING_TOO_LONG, COUNTY, COUNTRY, POSTCODE);
+            new PresenterAccountAddress(PREMISES, FIRST_LINE, STRING_TOO_LONG, TOWN_OR_CITY, COUNTRY, POSTCODE);
         });
         assertTrue(e.getMessage().contains("address line 2"));
     }
@@ -112,7 +121,7 @@ class PresenterAccountAddressTest {
     @DisplayName("Throw ValidationException by creating an invalid presenter address with too long country")
     void testInvalidPresenterAddressWithTooLongCountry() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, COUNTY, STRING_TOO_LONG, POSTCODE);
+            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, TOWN_OR_CITY, STRING_TOO_LONG, POSTCODE);
         });
         assertTrue(e.getMessage().contains("country"));
     }
@@ -121,7 +130,7 @@ class PresenterAccountAddressTest {
     @DisplayName("Throw ValidationException by creating an invalid presenter address with too long postcode")
     void testInvalidPresenterAddressWithTooLongPostcode() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, COUNTY, COUNTRY, STRING_TOO_LONG);
+            new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, TOWN_OR_CITY, COUNTRY, STRING_TOO_LONG);
         });
         assertTrue(e.getMessage().contains("postcode"));
     }
@@ -130,7 +139,7 @@ class PresenterAccountAddressTest {
     @DisplayName("Throw ValidationException by creating an invalid presenter addres with field with invalid character")
     void testInvalidPresenterAddressWithInvalidCharacter() {
         Exception e = assertThrows(ValidationException.class, () -> {
-            new PresenterAccountAddress(PREMISES, INVALID_STRING, SECOND_LINE, COUNTY, COUNTRY, POSTCODE);
+            new PresenterAccountAddress(PREMISES, INVALID_STRING, SECOND_LINE, TOWN_OR_CITY, COUNTRY, POSTCODE);
         });
         assertTrue(e.getMessage().contains("address line 1"));
     }

--- a/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddressTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountAddressTest.java
@@ -69,7 +69,7 @@ class PresenterAccountAddressTest {
         Exception e = assertThrows(ValidationException.class, () -> {
             new PresenterAccountAddress(PREMISES, FIRST_LINE, SECOND_LINE, "", COUNTRY, POSTCODE);
         });
-        assertTrue(e.getMessage().contains("town or city"));
+        assertTrue(e.getMessage().contains("townOrCity"));
     }
 
     @Test


### PR DESCRIPTION
Chnage the town or city field required.
If the town or city field is missing on the post request it returns HTTP status 400.

Resolves: [AOAF-303](https://companieshouse.atlassian.net/browse/AOAF-303)

[AOAF-303]: https://companieshouse.atlassian.net/browse/AOAF-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ