### PR TITLE
Allow prot override

### DIFF
--- a/ecs-image-build/docker_start.sh
+++ b/ecs-image-build/docker_start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Start script for presenter-account-api
-PORT=3000
+
+PORT="${PORT:-3000}"
 
 exec java -jar -Dserver.port="${PORT}" "presenter-account-api.jar"


### PR DESCRIPTION
Allow the PORT variable in docker_start script to have an override so that in local development it can be set to 8080 for Traefik.

See docker-chs-development PR: https://github.com/companieshouse/docker-chs-development/pull/1890