### PR TITLE
Make presenter name mandatory and improve validation error response

### DIFF
--- a/src/main/java/uk/gov/companieshouse/presenter/account/controller/PresenterAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/controller/PresenterAccountController.java
@@ -59,7 +59,7 @@ public class PresenterAccountController {
 
     @ExceptionHandler(ValidationException.class)
     ResponseEntity<String> validationException(final ValidationException e) {
-        return ResponseEntity.badRequest().body("Validation failed.");
+        return ResponseEntity.badRequest().body(e.getMessage() != null ? e.getMessage() : "Validation failed.");
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountName.java
+++ b/src/main/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountName.java
@@ -2,30 +2,26 @@ package uk.gov.companieshouse.presenter.account.model;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
-import org.springframework.lang.Nullable;
 import uk.gov.companieshouse.presenter.account.exceptionhandler.ValidationException;
 import uk.gov.companieshouse.presenter.account.validation.utils.StringValidator;
 
 public record PresenterAccountName(
-        @Field("forename") @Nullable String forename,
-        @Field("surname") @Nullable String surname) {
+        @Field("forename") String forename,
+        @Field("surname") String surname) {
 
     private static final int MAX_FORENAME_LENGTH = 32;
     private static final int MAX_SURNAME_LENGTH = 40;
 
     public PresenterAccountName(final String forename, final String surname) {
-        this.forename = validateName(forename, MAX_FORENAME_LENGTH);
-        this.surname = validateName(surname, MAX_SURNAME_LENGTH);
+        this.forename = validateName(forename, MAX_FORENAME_LENGTH, "forename");
+        this.surname = validateName(surname, MAX_SURNAME_LENGTH, "surname");
     }
 
-    private String validateName(final String name, final int maxLength) {
-        // CHS user profiles often don't have associated forename and surnames
-        // Therefore null is a valid value for the name field.
-        if (name == null || StringValidator.validateString(name, maxLength)) {
+    private String validateName(final String name, final int maxLength, final String fieldName) {
+        if (StringValidator.validateString(name, maxLength)) {
             return name;
         }
-
-        throw new ValidationException("Invalid Name");
+        throw new ValidationException("Invalid " + fieldName);
     }
 
     @Override

--- a/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountNameTest.java
+++ b/src/test/java/uk/gov/companieshouse/presenter/account/model/PresenterAccountNameTest.java
@@ -28,7 +28,7 @@ class PresenterAccountNameTest {
     }
 
     @Test
-    @DisplayName("Throw ValidationException by creating an invalid present name with empty names")
+    @DisplayName("Throw ValidationException by creating an invalid presenter name with empty names")
     void testInvalidPresenterNameWithoutFirstOrSurname() {
         Exception firstNameException = assertThrows(ValidationException.class, () -> {
             new PresenterAccountName("", LAST_NAME);
@@ -36,12 +36,25 @@ class PresenterAccountNameTest {
         Exception surnameException = assertThrows(ValidationException.class, () -> {
             new PresenterAccountName(FIRST_NAME, "");
         });
-        assertTrue(firstNameException.getMessage().contains("Name"));
-        assertTrue(surnameException.getMessage().contains("Name"));
+        assertTrue(firstNameException.getMessage().contains("forename"));
+        assertTrue(surnameException.getMessage().contains("surname"));
     }
 
     @Test
-    @DisplayName("Throw ValidationException by creating an invalid name with too long names")
+    @DisplayName("Throw ValidationException by creating an invalid presenter name with null names")
+    void testInvalidPresenterNameWithNullFirstOrSurname() {
+        Exception firstNameException = assertThrows(ValidationException.class, () -> {
+            new PresenterAccountName(null, LAST_NAME);
+        });
+        Exception surnameException = assertThrows(ValidationException.class, () -> {
+            new PresenterAccountName(FIRST_NAME, null);
+        });
+        assertTrue(firstNameException.getMessage().contains("forename"));
+        assertTrue(surnameException.getMessage().contains("surname"));
+    }
+
+    @Test
+    @DisplayName("Throw ValidationException by creating an invalid presenter with too long names")
     void testInvalidPresenterNameWithTooLongFirstOrSurname() {
         Exception firstNameException = assertThrows(ValidationException.class, () -> {
             new PresenterAccountName(TOO_LONG_NAME, LAST_NAME);
@@ -49,12 +62,12 @@ class PresenterAccountNameTest {
         Exception surnameException = assertThrows(ValidationException.class, () -> {
             new PresenterAccountName(FIRST_NAME, TOO_LONG_NAME);
         });
-        assertTrue(firstNameException.getMessage().contains("Name"));
-        assertTrue(surnameException.getMessage().contains("Name"));
+        assertTrue(firstNameException.getMessage().contains("forename"));
+        assertTrue(surnameException.getMessage().contains("surname"));
     }
 
     @Test
-    @DisplayName("Throw ValidationException by creating an invalid name with invalid characters names")
+    @DisplayName("Throw ValidationException by creating an invalid presenter with invalid characters names")
     void testInvalidPresenterNameWithInvalidCharacterFirstOrSurname() {
         Exception firstNameException = assertThrows(ValidationException.class, () -> {
             new PresenterAccountName(INVALID_CHARACTER_NAME, LAST_NAME);
@@ -62,18 +75,8 @@ class PresenterAccountNameTest {
         Exception surnameException = assertThrows(ValidationException.class, () -> {
             new PresenterAccountName(FIRST_NAME, INVALID_CHARACTER_NAME);
         });
-        assertTrue(firstNameException.getMessage().contains("Name"));
-        assertTrue(surnameException.getMessage().contains("Name"));
-    }
-
-    @Test
-    @DisplayName("Allows for null forename and surname in PresenterAccountName")
-    void testAllowsForNullForenameAndSurname() {
-        try {
-            new PresenterAccountName(null, null);
-        } catch (Exception e) {
-            fail("Creation of PresenterAccountName should not fail with null forename and surname");
-        }
+        assertTrue(firstNameException.getMessage().contains("forename"));
+        assertTrue(surnameException.getMessage().contains("surname"));
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces stricter validation for the `PresenterAccountName` model, ensuring that both forename and surname are required and must be valid, and improves error messaging throughout the codebase. The changes also update related tests to reflect the new validation logic and error messages.

### Validation logic improvements

* The `PresenterAccountName` record no longer allows `null` values for `forename` and `surname`, and now validates both fields with specific error messages indicating which field is invalid.

### Error handling improvements

* The `validationException` handler in `PresenterAccountController` now returns the specific error message from the thrown `ValidationException`, if available, instead of a generic message.

### Test updates

* The test suite for `PresenterAccountName` has been updated to expect failures when `null` or empty strings are provided for `forename` or `surname`, and to check that the error messages specify the correct field. Tests that previously allowed `null` values have been removed or updated accordingly.