### PR TITLE
Fix vulnerabilities in Spring Boot, Kafka Models, and SDKs vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <java.version>21</java.version>
 
         <!-- spring boot properties-->
-        <spring-boot-dependencies.version>4.0.1</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>4.0.5</spring-boot-dependencies.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
@@ -37,15 +37,21 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-build-helper-plugin.version>3.6.1</maven-build-helper-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <opentelemetry-instrumentation-bom.version>2.23.0</opentelemetry-instrumentation-bom.version>
+        <opentelemetry-instrumentation-bom.version>2.26.1</opentelemetry-instrumentation-bom.version>
 
         <!-- internal -->
         <structured-logging.version>3.0.37</structured-logging.version>
         <api-security-java-version>2.0.11</api-security-java-version>
-        <api-sdk-manager-java-library.version>3.0.10</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>4.0.331</private-api-sdk-java.version>
+        <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
+        <private-api-sdk-java.version>4.0.493</private-api-sdk-java.version>
         <ch-kafka.version>3.0.6</ch-kafka.version>
-        <kafka-models.version>3.0.26</kafka-models.version>
+        <kafka-models.version>3.0.30</kafka-models.version>
+
+        <!-- The tomcat-embedded dependencies can be removed if spring-boot > 4.0.5 fixed the vulnerabilities-->
+        <tomcat-embedded.version>11.0.21</tomcat-embedded.version>
+        <!-- The jetty-ee dependencies can be removed if kafka-models > 3.0.30 fixed the vulnerabilities-->
+        <jetty-ee.version>12.0.34</jetty-ee.version>
+        <jetty-ee-webapp.version>12.1.8</jetty-ee-webapp.version>
 
         <!--sonar configuration-->
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
@@ -99,6 +105,38 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- The tomcat-embedded dependencies can be removed if spring-boot > 4.0.5 fixed the vulnerabilities-->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat-embedded.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>11.0.21</version>
+                <scope>compile</scope>
+            </dependency>
+            <!-- The jetty-ee dependencies can be removed if kafka-models > 3.0.30 fixed the vulnerabilities-->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-ee</artifactId>
+                <version>${jetty-ee.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.ee</groupId>
+                <artifactId>jetty-ee-webapp</artifactId>
+                <version>${jetty-ee-webapp.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-webapp</artifactId>
+                <version>${jetty-ee-webapp.version}</version>
+                <scope>compile</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -134,12 +172,14 @@
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
+        <!-- This optional dependency contains vulnerabilities with no newer version
+             available. To be re-enabled if spring-boot > 4.0.5 fixed the vulnerabilities -->
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.boot</groupId>-->
+<!--            <artifactId>spring-boot-devtools</artifactId>-->
+<!--            <scope>runtime</scope>-->
+<!--            <optional>true</optional>-->
+<!--        </dependency>-->
         <!-- spring boot apis support libs ends-->
 
         <!-- spring boot test libs starts-->


### PR DESCRIPTION
This pull request updates several dependencies in the `pom.xml` file to address vulnerabilities and keep the project up-to-date. It also adds temporary dependencies for Tomcat and Jetty to mitigate known issues, and comments out the `spring-boot-devtools` dependency due to unresolved vulnerabilities.

**Dependency upgrades and vulnerability mitigations:**

* Upgraded `spring-boot-dependencies` to version 4.0.5, `opentelemetry-instrumentation-bom` to 2.26.1, `api-sdk-manager-java-library` to 3.0.19, `private-api-sdk-java` to 4.0.493, and `kafka-models` to 3.0.30 to incorporate the latest fixes and improvements. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L22-R22) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L40-R54)
* Added explicit dependencies for `tomcat-embed-core`, `tomcat-embed-websocket`, `jetty-ee`, `jetty-ee-webapp`, and `jetty-ee10-webapp` as a temporary measure to address vulnerabilities not yet fixed in upstream dependencies.
* Added version properties for Tomcat and Jetty dependencies to facilitate their management and future removal once vulnerabilities are resolved upstream.
* Commented out the `spring-boot-devtools` dependency due to unresolved vulnerabilities, with a note to re-enable it once a safe version is available.